### PR TITLE
Allow organizational repos to be backed up instead of user

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -16,6 +16,8 @@ GetOptions(
     "l|list"    => \$opts{list},
     "r|repos"   => \$opts{repos},
     "i|issues"  => \$opts{issues},
+    "o|org=s"   => \$opts{org},
+    "a|all"     => \$opts{all},
     "v|verbose" => \$opts{verbose},
     "h|help"    => \$help,
 );
@@ -60,6 +62,8 @@ Options:
 -p | --proxy    Optional proxy (https://proxy.example.com:PORT)
 -r | --repos    Back up all of your repositories
 -i | --issues   Back up all of your issues
+-o | --org      Back up the repositories of this organisation
+-a | --all      Back up all repositories for the authenticated user
 -h | --help     Display this help page
 
 EOF
@@ -69,7 +73,9 @@ my $gh = Github::Backup->new(
     api_user    => $opts{user},
     token   => $opts{token},
     dir     => $opts{dir},
-    proxy   => $opts{proxy}
+    proxy   => $opts{proxy},
+    org     => $opts{org},
+    all     => $opts{all}
 );
 
 if ($opts{list}) {

--- a/lib/Github/Backup.pm
+++ b/lib/Github/Backup.pm
@@ -42,6 +42,12 @@ has proxy => (
 has user => (
     is => 'rw',
 );
+has org => (
+    is => 'rw',
+);
+has all => (
+    is => 'rw',
+);
 has limit => (
     is => 'rw',
 );
@@ -102,7 +108,12 @@ sub list {
     my ($self) = @_;
 
     if (! $self->{repo_list}) {
-        my $repo_list = $self->gh->repos->list(user => $self->user);
+        my %params = $self->all
+            ? ()
+            : $self->org
+            ? (org => $self->org)
+            : (user => $self->user); # GH API: only public repos for this user
+        my $repo_list = $self->gh->repos->list(%params);
         while (my $repo = $repo_list->next) {
             push @{ $self->{repo_list} }, $repo;
         }


### PR DESCRIPTION
This PR adds 2 options, one to back up an organization's repos instead of a user's, and an option to back up all the authenticated user's repos instead of just their public ones (when the ```user``` is specified for the Github API, it will only back up that user's public repos).