### PR TITLE
Enable private repos to be cloned directly

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 bin/github-backup
+bin/github-backup-pass
 Changes
 examples/initial_test.pl
 lib/Github/Backup.pm

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ WriteMakefile(
     ABSTRACT_FROM    => 'lib/Github/Backup.pm',
     LICENSE          => 'perl_5',
     PL_FILES         => {},
-    EXE_FILES        => ['bin/github-backup'],
+    EXE_FILES        => ['bin/github-backup', 'bin/github-backup-pass'],
     MIN_PERL_VERSION => 5.006,
     META_MERGE => {
         'meta-spec' => { version => 2 },

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -74,7 +74,8 @@ EOF
 # command simply echos the GITHUB_TOKEN value, which can be used in place of a
 # password for authentication, thus allowing access to the private repos. This
 # option is ignored if it doesn't exist or returns nothing.
-$ENV{GIT_ASKPASS}="github_backup_pass";
+$ENV{GIT_ASKPASS}="github_backup_pass"
+    if $ENV{GITHUB_TOKEN};
 
 my $gh = Github::Backup->new(
     api_user    => $opts{user},

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -65,6 +65,17 @@ Options:
 EOF
     exit;
 }
+
+# If cloning private repos it is necessary to pass the authentication
+# information to the git command. It is not possible to do this using
+# Git::Repository, so an alternative is to use git's GIT_ASKPASS option, which
+# is a command to run that will return the password (it is not possible to pass
+# the password directly in an environment variable). The github_backup_pass
+# command simply echos the GITHUB_TOKEN value, which can be used in place of a
+# password for authentication, thus allowing access to the private repos. This
+# option is ignored if it doesn't exist or returns nothing.
+$ENV{GIT_ASKPASS}="github_backup_pass";
+
 my $gh = Github::Backup->new(
     api_user    => $opts{user},
     token   => $opts{token},

--- a/bin/github-backup-pass
+++ b/bin/github-backup-pass
@@ -1,0 +1,1 @@
+echo $GITHUB_TOKEN

--- a/lib/Github/Backup.pm
+++ b/lib/Github/Backup.pm
@@ -284,7 +284,11 @@ Mandatory: Your Github username.
 
 Mandatory: Your Github API token. If you wish to not include this on the
 command line, you can put the token into the C<GITHUB_TOKEN> environment
-variable.
+variable. Specifying the token in the C<GITHUB_TOKEN> environment variable also
+enables private repositories to be accessed, as github_backup will use the
+environment variable via the github_backup_pass command and git's
+C<GIT_ASKPASS> option to pass the required authentication information to git
+when cloning a repository.
 
 =head2 -l | --list
 


### PR DESCRIPTION
Currently private repos cannot be cloned / backed up without setting up some separate authentication for the git command. This PR enables use of the ```GITHUB_TOKEN``` value (if set) to be passed to git for use as authentication with Github. It does this using git's ```GIT_ASKPASS``` option which enables passing of authentication information (via an external command, which this PR includes).