### PR TITLE
Enable backup of all organisation's private repos

### DIFF
--- a/bin/github-backup
+++ b/bin/github-backup
@@ -78,7 +78,7 @@ EOF
 # command simply echos the GITHUB_TOKEN value, which can be used in place of a
 # password for authentication, thus allowing access to the private repos. This
 # option is ignored if it doesn't exist or returns nothing.
-$ENV{GIT_ASKPASS}="github_backup_pass"
+$ENV{GIT_ASKPASS}="github-backup-pass"
     if $ENV{GITHUB_TOKEN};
 
 my $gh = Github::Backup->new(

--- a/bin/github-backup
+++ b/bin/github-backup
@@ -78,7 +78,8 @@ EOF
 # command simply echos the GITHUB_TOKEN value, which can be used in place of a
 # password for authentication, thus allowing access to the private repos. This
 # option is ignored if it doesn't exist or returns nothing.
-$ENV{GIT_ASKPASS}="github_backup_pass";
+$ENV{GIT_ASKPASS}="github_backup_pass"
+    if $ENV{GITHUB_TOKEN};
 
 my $gh = Github::Backup->new(
     api_user    => $opts{user},


### PR DESCRIPTION
This PR:

1. Enables an organisation to be specified instead of a user
2. Provides helpers and information on how to backup private repos

The overall effect of this PR is to enable all repos (both private and public) of an organisation to be backed up